### PR TITLE
Add perfetto trace output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@
 # output files
 profiling.db
 profiling.csv
+profiling.pftrace
 trace.json

--- a/preciceprofiling/pftrace.py
+++ b/preciceprofiling/pftrace.py
@@ -1,0 +1,42 @@
+from preciceprofiling.common import Run
+import argparse
+import sys
+import pathlib
+from preciceprofiling.parsers import addInputArgument
+
+
+def makePFTraceParser(add_help: bool = True):
+    trace_help = "Transform profiling to the perfetto trace."
+    trace = argparse.ArgumentParser(description=trace_help, add_help=add_help)
+    addInputArgument(trace)
+    trace.add_argument(
+        "-o",
+        "--output",
+        default="profiling.pftrace",
+        type=pathlib.Path,
+        help="The resulting perfetto trace file",
+    )
+    return trace
+
+
+def runPFTrace(ns):
+    return pftraceCommand(ns.profilingfile, ns.output)
+
+
+def pftraceCommand(profilingfile, outfile):
+    run = Run(profilingfile)
+    print(f"Building perfetto trace")
+    trace = run.toPFTrace()
+    print(f"Writing to {outfile}")
+    outfile.write_bytes(trace)
+    return 0
+
+
+def main():
+    parser = makePFTraceParser()
+    ns = parser.parse_args()
+    return runPFTrace(ns)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name="precice-profiling"
 dynamic = [ "version" ]
 dependencies = [
-    "typing_extensions", "orjson >= 3", "polars >= 0.19.0", "matplotlib"
+    "typing_extensions", "orjson >= 3", "polars >= 0.19.0", "matplotlib", "perfetto"
 ]
 requires-python = ">=3.10"
 authors = [
@@ -40,6 +40,7 @@ precice-profiling-analyze = "preciceprofiling.analyze:main"
 precice-profiling-trace = "preciceprofiling.trace:main"
 precice-profiling-export = "preciceprofiling.export:main"
 precice-profiling-histogram = "preciceprofiling.histogram:main"
+precice-profiling-pftrace = "preciceprofiling.pftrace:main"
 
 [tool.setuptools]
 packages=["preciceprofiling"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,7 @@ from preciceprofiling.merge import mergeCommand
 from preciceprofiling.analyze import analyzeCommand
 from preciceprofiling.export import exportCommand
 from preciceprofiling.trace import traceCommand
+from preciceprofiling.pftrace import pftraceCommand
 
 
 def get_cases():
@@ -22,6 +23,7 @@ def run_case(case: pathlib.Path, cwd: pathlib.Path, useDir: bool):
     profiling = cwd / "profiling.db"
     export = cwd / "profiling.csv"
     trace = cwd / "trace.json"
+    pftrace = cwd / "profiling.pftrace"
     unit = "us"
 
     mergeInputs = (
@@ -41,6 +43,10 @@ def run_case(case: pathlib.Path, cwd: pathlib.Path, useDir: bool):
     print("--- Trace")
     assert traceCommand(profiling, trace, unit, None, False) == 0
     assert trace.exists()
+
+    print("--- Perfetto trace")
+    assert pftraceCommand(profiling, pftrace) == 0
+    assert pftrace.exists()
 
     participants = (
         pl.read_csv(cwd / "profiling.csv").get_column("participant").unique().to_list()


### PR DESCRIPTION
This PR add the command `precice-profiling-pftrace` which generates a perfetto trace file.
This is significantly more space efficient than the `trace.json`, which allows loading larger traces in the UI.

I tried both the in-memory and the streaming builder.
For my test case of 2.5M events, the streaming builder uses around 1.6GB peak memory and takes 16s, while the in-memory builder uses 3GB and takes 11s.

Let's switch to the streaming processor once this actually becomes an issue.