### PR TITLE
Add data as debug annotations to pftrace

### DIFF
--- a/preciceprofiling/common.py
+++ b/preciceprofiling/common.py
@@ -259,6 +259,13 @@ class Run:
                     entry.name = name
                 pkt.sequence_flags = TracePacket.SEQ_NEEDS_INCREMENTAL_STATE
 
+                # add data
+                if e.data:
+                    for key, value in json.loads(e.data).items():
+                        annotation = pkt.track_event.debug_annotations.add()
+                        annotation.name = key
+                        annotation.int_value = value
+
             # end leftover events
             for a in active:
                 pkt = builder.add_packet()


### PR DESCRIPTION
According to the docs https://perfetto.dev/docs/getting-started/converting#python-example-basic-debug-annotations

This allows extracting this information directly via SQL:

```sql
select thread_name, EXTRACT_ARG(arg_set_id, 'debug.meshSizeB-Mesh') AS mesh_size
from thread_slice
where name = 'initialize' and process_name = 'B'
```