### PR TITLE
Add total as alias for _GLOBAL in analyze

### DIFF
--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -117,6 +117,10 @@ def runAnalyze(ns):
 
 
 def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
+    # Translate display name "total" back to internal name "_GLOBAL"
+    if event == "total":
+        event = "_GLOBAL"
+
     run = Run(profilingfile)
 
     participants = run.participants()


### PR DESCRIPTION
Fixes #18

## Problem
The `total` event shown in the tabular view is stored internally as `_GLOBAL`. 
When a user passed `--event total`, it failed to match correctly because the 
lookup compared against the raw internal name in the database.

## Fix
Added a translation at the start of `analyzeCommand` that maps the display 
name `total` back to the internal name `_GLOBAL` before any lookup is performed.

Now both of these work correctly:
- `precice-cli profiling analyze <participant> --event total`
- `precice-cli profiling analyze <participant> --event _GLOBAL`