### PR TITLE
Make participant argument optional, analyze all if omitted

### DIFF
--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -214,8 +214,10 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     run = Run(profilingfile)
     all_participants = run.participants()
 
-    assert participant is None or participant in all_participants, (
-        f"Given participant {participant} doesn't exist. Known: " + ", ".join(all_participants)
+    assert (
+        participant is None or participant in all_participants
+    ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
+        all_participants
     )
 
     print(f"Output timings are in {unit}.")

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -117,6 +117,10 @@ def runAnalyze(ns):
 
 
 def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
+    # Translate display name "total" back to internal name "_GLOBAL"
+    if event == "total":
+        event = "_GLOBAL"
+
     run = Run(profilingfile)
 
     participants = run.participants()

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -11,7 +11,7 @@ def makeAnalyzeParser(add_help: bool = True):
     Parallel solvers show events of the primary rank next to the secondary ranks spending the least and most time in advance of preCICE.
     """
     analyze = argparse.ArgumentParser(description=analyze_help, add_help=add_help)
-    analyze.add_argument("participant", type=str, help="The participant to analyze")
+    analyze.add_argument("participant", type=str, nargs="?", default=None, help="The participant to analyze. If omitted, all participants are analyzed.")
     addInputArgument(analyze)
     addUnitArgument(analyze)
     analyze.add_argument(
@@ -123,11 +123,18 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
 
     run = Run(profilingfile)
 
-    participants = run.participants()
+    all_participants = run.participants()
+
+    if participant is None:
+        for p in all_participants:
+            print(f"\n=== Participant: {p} ===")
+            analyzeCommand(profilingfile, p, event, outfile, unit)
+        return 0
+
     assert (
-        participant in participants
+        participant in all_participants
     ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
-        participants
+        all_participants
     )
 
     df = run.toDataFrame(participant=participant)

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -132,9 +132,16 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     all_participants = run.participants()
 
     if participant is None:
+        if outfile is not None:
+            print(
+                "Error: --output requires a specific participant. "
+                "Use `analyze <participant> --output <file>`.",
+                file=sys.stderr,
+            )
+            return 1
         for p in all_participants:
             print(f"\n=== Participant: {p} ===")
-            analyzeCommand(profilingfile, p, event, outfile, unit)
+            analyzeCommand(profilingfile, p, event, None, unit)
         return 0
 
     assert (

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -123,10 +123,8 @@ def runAnalyze(ns):
 
 
 def computeAnalysis(run, participant, event, unit="us"):
-    """Compute and print the analysis DataFrame for a single participant."""
+    """Compute the analysis DataFrame for a single participant."""
     df = run.toDataFrame(participant=participant)
-
-    print(f"Output timing are in {unit}.")
 
     dur_factor = 1000 * ns_to_unit_factor(unit)
     df = (
@@ -205,7 +203,6 @@ def computeAnalysis(run, participant, event, unit="us"):
             .collect()
         )
 
-    printWide(joined)
     return joined
 
 
@@ -217,6 +214,12 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     run = Run(profilingfile)
     all_participants = run.participants()
 
+    assert participant is None or participant in all_participants, (
+        f"Given participant {participant} doesn't exist. Known: " + ", ".join(all_participants)
+    )
+
+    print(f"Output timings are in {unit}.")
+
     if participant is None:
         if outfile is not None:
             print(
@@ -227,16 +230,11 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
             return 1
         for p in all_participants:
             print(f"\n=== Participant: {p} ===")
-            computeAnalysis(run, p, event, unit)
+            printWide(computeAnalysis(run, p, event, unit))
         return 0
 
-    assert (
-        participant in all_participants
-    ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
-        all_participants
-    )
-
     joined = computeAnalysis(run, participant, event, unit)
+    printWide(joined)
 
     if outfile:
         print(f"Writing to {outfile}")

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -122,40 +122,12 @@ def runAnalyze(ns):
     )
 
 
-def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
-    # Translate display name "total" back to internal name "_GLOBAL"
-    if event == "total":
-        event = "_GLOBAL"
-
-    run = Run(profilingfile)
-
-    all_participants = run.participants()
-
-    if participant is None:
-        if outfile is not None:
-            print(
-                "Error: --output requires a specific participant. "
-                "Use `analyze <participant> --output <file>`.",
-                file=sys.stderr,
-            )
-            return 1
-        for p in all_participants:
-            print(f"\n=== Participant: {p} ===")
-            analyzeCommand(profilingfile, p, event, None, unit)
-        return 0
-
-    assert (
-        participant in all_participants
-    ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
-        all_participants
-    )
-
+def computeAnalysis(run, participant, event, unit="us"):
+    """Compute and print the analysis DataFrame for a single participant."""
     df = run.toDataFrame(participant=participant)
 
     print(f"Output timing are in {unit}.")
 
-    # Filter by participant
-    # Convert duration to requested unit
     dur_factor = 1000 * ns_to_unit_factor(unit)
     df = (
         df.filter(pl.col("participant") == participant)
@@ -234,6 +206,37 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
         )
 
     printWide(joined)
+    return joined
+
+
+def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
+    # Translate display name "total" back to internal name "_GLOBAL"
+    if event == "total":
+        event = "_GLOBAL"
+
+    run = Run(profilingfile)
+    all_participants = run.participants()
+
+    if participant is None:
+        if outfile is not None:
+            print(
+                "Error: --output requires a specific participant. "
+                "Use `analyze <participant> --output <file>`.",
+                file=sys.stderr,
+            )
+            return 1
+        for p in all_participants:
+            print(f"\n=== Participant: {p} ===")
+            computeAnalysis(run, p, event, unit)
+        return 0
+
+    assert (
+        participant in all_participants
+    ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
+        all_participants
+    )
+
+    joined = computeAnalysis(run, participant, event, unit)
 
     if outfile:
         print(f"Writing to {outfile}")

--- a/preciceprofiling/analyze.py
+++ b/preciceprofiling/analyze.py
@@ -11,7 +11,13 @@ def makeAnalyzeParser(add_help: bool = True):
     Parallel solvers show events of the primary rank next to the secondary ranks spending the least and most time in advance of preCICE.
     """
     analyze = argparse.ArgumentParser(description=analyze_help, add_help=add_help)
-    analyze.add_argument("participant", type=str, nargs="?", default=None, help="The participant to analyze. If omitted, all participants are analyzed.")
+    analyze.add_argument(
+        "participant",
+        type=str,
+        nargs="?",
+        default=None,
+        help="The participant to analyze. If omitted, all participants are analyzed.",
+    )
     addInputArgument(analyze)
     addUnitArgument(analyze)
     analyze.add_argument(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -86,3 +86,24 @@ def test_truncated_case(case: pathlib.Path, useDir: bool):
         cwd = pathlib.Path(tmp)
         truncate_case_files(case, cwd)
         run_case(cwd, cwd, useDir)
+
+
+def test_analyze_all_participants():
+    """analyze with no participant should analyze all participants"""
+    case = pathlib.Path(__file__).parent / "cases" / "fiveparticipants-json"
+    with tempfile.TemporaryDirectory() as tmp:
+        cwd = pathlib.Path(tmp)
+        profiling = cwd / "profiling.db"
+        assert mergeCommand([case], profiling, True) == 0
+        assert analyzeCommand(profiling, None, "advance", None, "us") == 0
+
+
+def test_analyze_no_participant_with_outfile_errors():
+    """analyze with no participant but --output should return error"""
+    case = pathlib.Path(__file__).parent / "cases" / "fiveparticipants-json"
+    with tempfile.TemporaryDirectory() as tmp:
+        cwd = pathlib.Path(tmp)
+        profiling = cwd / "profiling.db"
+        assert mergeCommand([case], profiling, True) == 0
+        result = analyzeCommand(profiling, None, "advance", cwd / "out.csv", "us")
+        assert result == 1


### PR DESCRIPTION
Fixes #7

## Problem
Running `precice-cli profiling analyze` with no participant argument led to an 
error instead of showing stats for all participants.

## Fix
- Made `participant` an optional positional argument (`nargs="?"`, `default=None`)
- If no participant is provided, `analyzeCommand` now loops over all participants 
  and displays analysis for each one

Now both of these work correctly:
- `precice-cli profiling analyze <participant>` — analyze a single participant
- `precice-cli profiling analyze` — analyze all participants